### PR TITLE
avoid trailing dashes

### DIFF
--- a/lib/babosa/identifier.rb
+++ b/lib/babosa/identifier.rb
@@ -165,7 +165,7 @@ module Babosa
     #   "üéøá".to_identifier.truncate(3) #=> "üéø"
     # @return String
     def truncate!(max)
-      @wrapped_string = unpack("U*")[0...max].pack("U*")
+      @wrapped_string = unpack("U*")[0...max].pack("U*").sub(/(\s)+$/u, '')
     end
 
     # Truncate the string to +max+ bytes. This can be useful for ensuring that
@@ -187,7 +187,7 @@ module Babosa
           new << char
         end
       end
-      @wrapped_string = new.join
+      @wrapped_string = new.join.sub(/(\s)+$/u, '')
     end
 
     # Replaces whitespace with dashes ("-").

--- a/test/babosa_test.rb
+++ b/test/babosa_test.rb
@@ -158,6 +158,10 @@ class  BabosaTest < Test::Unit::TestCase
     assert_equal "üa", "üa".to_slug.truncate!(100)
   end
 
+  test "should not leave trailing '-' when normalized and truncated" do
+    assert_equal "no", "no trailing dash".to_slug.normalize!(:max_length => 3)
+  end
+
   test "should transliterate uncomposed utf8" do
     string = [117, 776].pack("U*") # "ü" as ASCII "u" plus COMBINING DIAERESIS
     assert_equal "u", string.to_slug.approximate_ascii!


### PR DESCRIPTION
This commit avoids trailing dashes that can be generated if the string was truncated and ended with a space. So I'm dropping all trailing spaces after truncating a string.
