### PR TITLE
Allow to use multiple transliterators

### DIFF
--- a/lib/babosa/identifier.rb
+++ b/lib/babosa/identifier.rb
@@ -112,9 +112,13 @@ module Babosa
     #   string.transliterate!                 # => "¡Feliz anio!"
     # @param *args <Symbol>
     # @return String
-    def transliterate!(kind = nil)
-      transliterator = Transliterator.get(kind || :latin).instance
-      @wrapped_string = transliterator.transliterate(@wrapped_string)
+    def transliterate!(*kinds)
+      kinds = [:latin] if kinds.empty?
+      kinds.each do |kind|
+        transliterator = Transliterator.get(kind).instance
+        @wrapped_string = transliterator.transliterate(@wrapped_string)
+      end
+      @wrapped_string
     end
 
     # Converts dashes to spaces, removes leading and trailing spaces, and

--- a/spec/babosa_spec.rb
+++ b/spec/babosa_spec.rb
@@ -34,6 +34,11 @@ describe Babosa::Identifier do
       string = [117, 776].pack("U*") # "ü" as ASCII "u" plus COMBINING DIAERESIS
       string.to_slug.approximate_ascii.should eql("u")
     end
+
+    it "should transliterate using multiple transliterators" do
+      string = "свободное režģis"
+      string.to_slug.approximate_ascii(:latin, :russian).should eql("svobodnoe rezgis")
+    end
   end
 
   describe "#downcase" do


### PR DESCRIPTION
Since the `:transliterations` options accepts `Array`, it should allow to specify multiple transliterations.

```
>> "свободное režģis".to_slug.normalize(:transliterations => [:latin])
свободное-rezgis
>> "свободное režģis".to_slug.normalize(:transliterations => [:russian])
svobodnoe-režģis
>> "свободное režģis".to_slug.normalize(:transliterations => [:latin, :russian])
ArgumentError: wrong number of arguments (2 for 1)
```

With my changes this will work:

```
>> "свободное režģis".to_slug.normalize(:transliterations => [:latin, :russian])
svobodnoe-rezgis
```
