### PR TITLE
Fixed Ruby 1.8.7 compatibility

### DIFF
--- a/lib/babosa/identifier.rb
+++ b/lib/babosa/identifier.rb
@@ -113,6 +113,7 @@ module Babosa
     # @param *args <Symbol>
     # @return String
     def transliterate!(*kinds)
+      kinds.compact!
       kinds = [:latin] if kinds.empty?
       kinds.each do |kind|
         transliterator = Transliterator.get(kind).instance


### PR DESCRIPTION
What was happening was `*kinds` was creating an array resembling `[nil`] and so `kinds = [:latin]` was not being evaluated as the array was not `.empty?`

What I've done is told the array to compact before checking emptiness and also before looping. 

This resolves the issue.
