### PR TITLE
Remove unnecessary Java module include

### DIFF
--- a/lib/babosa/utf8/java_proxy.rb
+++ b/lib/babosa/utf8/java_proxy.rb
@@ -1,5 +1,3 @@
-include Java
-
 module Babosa
   module UTF8
     # A UTF-8 proxy module using Java's built-in Unicode support. Requires JRuby 1.5+.


### PR DESCRIPTION
There is no need to include Java module in main object.
It allows to call java classes without 'Java::' prefix but this functionality should be application specific and not forced by gem.

``` ruby
>> self.class.ancestors
[
  [0] Object < BasicObject,
  [1] Kernel,
  [2] BasicObject
]
>> require 'babosa'
true
>> self.class.ancestors
[
  [0] Object < BasicObject,
  [1] Java,
  [2] Kernel,
  [3] BasicObject
]
>>
```
