### PR TITLE
More detailed check for unicode gem

### DIFF
--- a/lib/babosa/identifier.rb
+++ b/lib/babosa/identifier.rb
@@ -37,7 +37,7 @@ module Babosa
 
     @@utf8_proxy = if Babosa.jruby15?
       UTF8::JavaProxy
-    elsif defined? Unicode
+    elsif defined? Unicode::VERSION
       UTF8::UnicodeProxy
     elsif defined? ActiveSupport
       UTF8::ActiveSupportProxy


### PR DESCRIPTION
Hi @norman,

I am author of a gem that adds the ability to check for the width of a unicode string: https://github.com/janlelis/unicode-display_width

It lives well together with the unicode gem and does not interfere with it in any way, however, it uses the same `Unicode` namespace.

Since babosa uses the `Unicode` constant to determine, if the unicode-display_width gem is available, but the unicode gem is not available, it will lead to a `LoadError`: https://github.com/janlelis/unicode-display_width/issues/4

The proposed fix is to check for a `VERSION` constant, which is typically only defined for the gem of the namespace itself.
