### PR TITLE
Update to RSpec 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 language: ruby
+sudo: false
 rvm:
-  #- 2.2.0
+  - 2.5.0
+  - 2.4.0
+  - 2.3.0
+  - 2.2.0
   - 2.1.0
   - 2.0.0
   - jruby
-  - rbx
+  - rbx-2
 branches:
   only:
     - master
+matrix:
+  allow_failures:
+    - rvm: rbx-2

--- a/babosa.gemspec
+++ b/babosa.gemspec
@@ -20,7 +20,7 @@ spec = Gem::Specification.new do |s|
     'Rakefile', 'init.rb', 'generators/**/*.*', 'spec/**/*.*', '.gemtest']
 
   s.add_development_dependency 'activesupport', '>= 3.2.0'
-  s.add_development_dependency 'rspec', '~> 3.1.0'
+  s.add_development_dependency 'rspec', '~> 3.7.0'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'unicode'


### PR DESCRIPTION
Rake has deprecated and removed `last_comment`.
This PR updates the RSpec version to one that no longer depends on this

Also updates `travis.yml` to include modern rubies, and allow `RBX` failures