### PR TITLE
Duplicate strings to avoid freezing empty strings cast from nil

### DIFF
--- a/lib/babosa/identifier.rb
+++ b/lib/babosa/identifier.rb
@@ -166,8 +166,8 @@ module Babosa
     # Normalize a string so that it can safely be used as a Ruby method name.
     def to_ruby_method!(allow_bangs = true)
       leader, trailer = @wrapped_string.strip.scan(/\A(.+)(.)\z/).flatten
-      leader          = leader.to_s
-      trailer         = trailer.to_s
+      leader          = leader.to_s.dup
+      trailer         = trailer.to_s.dup
       if allow_bangs
         trailer.downcase!
         trailer.gsub!(/[^a-z0-9!=\\?]/, '')


### PR DESCRIPTION
Closes: https://github.com/norman/babosa/issues/51

Objects can be nil, which when cast to Strings yield frozen strings [0]
which cannot be mutated using methods like `downcase!`.

[0] https://bugs.ruby-lang.org/issues/16150?next_issue_id=16184

Signed-off-by: Balasankar "Balu" C <balasankarc@autistici.org>