### PR TITLE
Add `racc` for jruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@
 source "https://rubygems.org"
 gemspec
 
-gem 'racc', platform: :jruby
+gem "racc", platform: :jruby

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@
 # easily install gems. However, Babosa does not use Bundler internally.
 source "https://rubygems.org"
 gemspec
+
+gem 'racc', platform: :jruby


### PR DESCRIPTION
It appears that unless we add `racc` to the Gemfile, specifically
for the platform `jruby`, it raises a `LoadError`:

    LoadError: no such file to load -- racc/info

Adding `racc` to the Gemfile fixes this.