### PR TITLE
Also run CI on pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [ push ]
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
Previously we'd only find out if we had failures once we merged a pull
request, which is not very helpful.