### PR TITLE
Stop bundling twice on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,9 +20,9 @@ jobs:
 
     name: ${{ matrix.ruby }}
     steps:
+      - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
-      - uses: actions/checkout@v2
       - run: bundle exec rake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,6 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      BUNDLE_JOBS: 4
-      BUNDLE_PATH: vendor/bundle
       CI: true
 
     name: ${{ matrix.ruby }}
@@ -27,5 +25,4 @@ jobs:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
       - uses: actions/checkout@v2
-      - run: bundle install --path vendor/bundle
       - run: bundle exec rake


### PR DESCRIPTION
We were asking `ruby/setup-ruby` to bundle and we were then bundling
ourselves, which wasted time.