### PR TITLE
Run CI with Ruby 3.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, jruby, truffleruby-head ]
+        ruby: [ 2.5, 2.6, 2.7, 3.0, jruby, truffleruby-head ]
       fail-fast: false
       max-parallel: 10
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ruby 3.0 has been out for a while and it makes sense to test babosa with
it on CI.

Doing this has revealed that `to_ruby_method` didn't work, so I've fixed
that.