### PR TITLE
Only strip leading digits when using `to_ruby_method`.

### DIFF
--- a/lib/babosa/identifier.rb
+++ b/lib/babosa/identifier.rb
@@ -148,8 +148,8 @@ module Babosa
       transliterate!
       to_ascii!
       word_chars!
-      clean!
       strip_leading_digits!
+      clean!
       @wrapped_string += last_char if allow_bangs && ["!", "?"].include?(last_char)
       raise Error, "Input generates impossible Ruby method name" if self == ""
 

--- a/lib/babosa/identifier.rb
+++ b/lib/babosa/identifier.rb
@@ -110,7 +110,7 @@ module Babosa
       # `^\p{letter}` = Any non-Unicode letter
       # `&&` = add the following character class
       # `[^ _\n\r]` = Anything other than space, underscore, newline or linefeed
-      gsub!(/[[^\p{letter}]&&[^ _\-\n\r]]/, "")
+      gsub!(/[[^\p{letter}]&&[^ \d_\-\n\r]]/, "")
       to_s
     end
 
@@ -149,6 +149,7 @@ module Babosa
       to_ascii!
       word_chars!
       clean!
+      strip_leading_digits!
       @wrapped_string += last_char if allow_bangs && ["!", "?"].include?(last_char)
       raise Error, "Input generates impossible Ruby method name" if self == ""
 
@@ -206,6 +207,14 @@ module Babosa
       to_s
     end
 
+    # Strip any leading digits.
+    #
+    # @return String
+    def strip_leading_digits!
+      gsub!(/^\d+/, "")
+      to_s
+    end
+
     # Attempt to convert characters encoded using CP1252 and IS0-8859-1 to
     # UTF-8.
     # @return String
@@ -216,9 +225,9 @@ module Babosa
       to_s
     end
 
-    %w[clean downcase normalize normalize_utf8 tidy_bytes to_ascii
-       transliterate truncate truncate_bytes upcase with_separators
-       word_chars].each do |method|
+    %w[clean downcase normalize normalize_utf8 strip_leading_digits
+       tidy_bytes to_ascii transliterate truncate truncate_bytes upcase
+       with_separators word_chars].each do |method|
       class_eval(<<-METHOD, __FILE__, __LINE__ + 1)
         def #{method}(*args)
           with_new_instance { |id| id.send(:#{method}!, *args) }

--- a/spec/identifier_spec.rb
+++ b/spec/identifier_spec.rb
@@ -16,9 +16,9 @@ describe Babosa::Identifier do
   end
 
   describe "#word_chars" do
-    it "word_chars! should leave only letters and spaces" do
-      string = "a*$%^$@!@b$%^&*()*!c"
-      expect(string.to_slug.word_chars!).to match(/[a-z ]*/i)
+    it "word_chars! should leave only letters, numbers, and spaces" do
+      string = "a*$%^$@!@b$%^&*()*!c 123"
+      expect(string.to_slug.word_chars!).to eq "abc 123"
     end
   end
 
@@ -139,6 +139,7 @@ describe Babosa::Identifier do
       expect("カタカナ: katakana is über cool".to_slug.to_ruby_method).to eql("katakana_is_uber_cool")
       expect("カタカナ: katakana is über cool!".to_slug.to_ruby_method).to eql("katakana_is_uber_cool!")
       expect("カタカナ: katakana is über cool".to_slug.to_ruby_method(allow_bangs: false)).to eql("katakana_is_uber_cool")
+      expect("not 2 much 4 ruby".to_slug.to_ruby_method(allow_bangs: false)).to eql("not_2_much_4_ruby")
     end
 
     it "should optionally remove trailing punctuation" do
@@ -146,7 +147,6 @@ describe Babosa::Identifier do
     end
 
     it "should raise an error when it would generate an impossible method name" do
-      # "1".to_identifier.to_ruby_method
       expect { "1".to_identifier.to_ruby_method }.to raise_error(Babosa::Identifier::Error)
     end
 

--- a/spec/identifier_spec.rb
+++ b/spec/identifier_spec.rb
@@ -139,7 +139,7 @@ describe Babosa::Identifier do
       expect("カタカナ: katakana is über cool".to_slug.to_ruby_method).to eql("katakana_is_uber_cool")
       expect("カタカナ: katakana is über cool!".to_slug.to_ruby_method).to eql("katakana_is_uber_cool!")
       expect("カタカナ: katakana is über cool".to_slug.to_ruby_method(allow_bangs: false)).to eql("katakana_is_uber_cool")
-      expect("not 2 much 4 ruby".to_slug.to_ruby_method(allow_bangs: false)).to eql("not_2_much_4_ruby")
+      expect("not 2 much 4 ruby".to_slug.to_ruby_method).to eql("not_2_much_4_ruby")
     end
 
     it "should optionally remove trailing punctuation" do


### PR DESCRIPTION
When about to release 2.0.0, while testing its integration with an
application, I noticed a regression in `word_chars!` where it would
strip all digits from a string when using `to_slug`. This also didn't
match the docs for the method, as described in #65.

After allowing it to preserve digits this broke `to_ruby_method` because
it was able to create strings like `1` which would result in an invalid
method name. I introduced a new method `strip_leading_digits!` which
takes care of this requirement.

Fixes #65.