### PR TITLE
Change normalizing code example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ class Person < ActiveRecord::Base
   friendly_id :name, use: :slugged
 
   def normalize_friendly_id(input)
-    input.to_s.to_slug.normalize(transliterations: :russian).to_s
+    input.to_slug.transliterate(:ukrainian).normalize.to_s
   end
 end
 ```


### PR DESCRIPTION
For Rails 7 and friendly_id v5.4.0, the code example was a little bit not good, 'cause not transliterates slug, but this solution is pretty good