### PR TITLE
Update required ruby version to `>= 2.6.0`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, 3.0, jruby, truffleruby-head ]
+        ruby: [ 2.6, 2.7, 3.0, jruby, truffleruby-head ]
       fail-fast: false
       max-parallel: 10
     runs-on: ubuntu-latest

--- a/babosa.gemspec
+++ b/babosa.gemspec
@@ -25,6 +25,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", ">= 3.7.0"
   s.add_development_dependency "standard", ">= 1.1.7"
   s.add_development_dependency "simplecov"
+  
+  s.required_ruby_version = ">= 2.6.0"
 
   s.cert_chain = [File.expand_path("certs/parndt.pem", __dir__)]
   if $PROGRAM_NAME.end_with?("gem") && ARGV.include?("build") && ARGV.include?(__FILE__)


### PR DESCRIPTION
In #69 we re-added Emoji support and this makes use of `{Extended Pictograph}`
but we now see this error with Ruby 2.5 (and, presumably, below):

> invalid character property name {Extended_Pictographic}: 
> /[[^\p{letter}]&&[^ \d_\-\n\r\p{Extended_Pictographic}]]/

Ruby 2.5 is no longer supported as it was marked end of life since 
[31 Mar 2021](https://endoflife.date/ruby) so we might as well drop
support for it in this library rather than trying to fix this issue.