### PR TITLE
Add Ruby 3.1 and 3.2 to CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [ 2.6, 2.7, 3.0, jruby, truffleruby-head ]
+        ruby: [ 2.6, 2.7, 3.0, 3.1, 3.2, jruby, truffleruby-head ]
       fail-fast: false
       max-parallel: 10
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,8 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [ 2.6, 2.7, 3.0, 3.1, 3.2, jruby, truffleruby-head ]
+        ruby: [ 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0, jruby, truffleruby-head ]
       fail-fast: false
-      max-parallel: 10
     runs-on: ubuntu-latest
 
     env:
@@ -20,7 +19,7 @@ jobs:
 
     name: ${{ matrix.ruby }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true


### PR DESCRIPTION
* These have been out for a while and it is helpful to know if this gem is compatible with them https://www.ruby-lang.org/en/downloads/releases/