### PR TITLE
Make the build reproducible

### DIFF
--- a/babosa.gemspec
+++ b/babosa.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |s|
   
   s.required_ruby_version = ">= 2.6.0"
 
-  s.cert_chain = [File.expand_path("certs/parndt.pem", __dir__)]
   if $PROGRAM_NAME.end_with?("gem") && ARGV.include?("build") && ARGV.include?(__FILE__)
+    s.cert_chain = [File.expand_path("certs/parndt.pem", __dir__)]
     s.signing_key = File.expand_path("~/.ssh/gem-private_key.pem")
   end
 end

--- a/babosa.gemspec
+++ b/babosa.gemspec
@@ -27,9 +27,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency "simplecov"
   
   s.required_ruby_version = ">= 2.6.0"
-
-  if $PROGRAM_NAME.end_with?("gem") && ARGV.include?("build") && ARGV.include?(__FILE__)
-    s.cert_chain = [File.expand_path("certs/parndt.pem", __dir__)]
-    s.signing_key = File.expand_path("~/.ssh/gem-private_key.pem")
-  end
 end


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort I noticed that babosa could not be built reproducibly.

This is because the `__dir__` gets expanded when building/rendering the `.gemspec` file which is then shipped in the binary package. As this path is dependent on the path in which you build babosa, this makes the build unreproducible.

I think that cert_chain is only needed if signing_key is needed, so moving it under the same conditional seems to be safe. The goal, however, is to prevent cert_chain from being included in regular, "normal", builds of the package.

I originally filed this in Debian as [bug #1041840](https://bugs.debian.org/1041840).