### PR TITLE
Add trusted publishing support for RubyGems.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release Gem to rubygems.org
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  push:
+    if: github.repository == 'norman/babosa'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      # Set up
+      - uses: actions/checkout@v6
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      # Release
+      - uses: rubygems/release-gem@v1

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rubygems"
+require "bundler/gem_helper"
 require "rake/testtask"
 require "rake/clean"
 require "rubygems/package_task"
@@ -31,3 +32,5 @@ end
 
 require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
+
+Bundler::GemHelper.install_tasks(name: "babosa")


### PR DESCRIPTION
This allows us to publish gems simply by releasing a new tag.